### PR TITLE
FIX better display multiline error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All unreleased changes should be added to appropriate section bellow
 
 ### Added
 New features
-- detox_bridge.node module to control the node.js bridge
+- 
 
 ### Changed
 Changes in existing functionality
@@ -31,6 +31,13 @@ Any bug fixes
 Invite users to upgrade in case of vulnerabilities
 - 
 
-## [0.0.1] - YYYY-MM-DD
+## [1.0.0] (2017-07-11)
+
+### Added
+New features
+
+- detox_bridge functions to run tests using detox
+- detox_bridge.node module to control the node.js bridge
+- detox_bridge.js module to generate js code with python expressions
 
 Adhere to [semantic versioning](http://semver.org/) and [ISO date format](http://www.iso.org/iso/home/standards/iso8601.htm)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,10 @@
 include README.rst
 include CHANGELOG.md
 
+recursive-exclude detox *
 recursive-exclude tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat
+recursive-include detox_bridge *.js

--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,43 @@ NODE
 ----
 
 The code emitted by this bridge requires node 7.6.0 or higher.
+
+
+Usage
+=====
+
+.. code:: python
+
+   from detox_bridge import await, by, detox, device, element, expect, node_with_detox
+
+   app_path = "detox/examples/demo-react-native"
+
+   # Start Node server in app_path root folder that contains node_modules
+
+   with node_with_detox(app_path=app_path, default_timeout=10) as appserver:
+
+       # Detox Config (we could also load this from package.json)
+
+       ios_sim_release = {
+           "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+           "type": "ios.simulator",
+           "name": "iPhone 7 Plus"
+       }
+
+       configurations_obj = {"configurations": {"ios.sim.release": ios_sim_release}}
+
+       # Longer timeout since the app may be installed
+
+       appserver(await(detox.init(configurations_obj)), timeout=360)
+
+       # Reload react native
+
+       appserver(await(device.reloadReactNative()))
+
+       # Expectation
+
+       appserver(await(expect(element(by.id('welcome'))).toBeVisible()))
+
+       # Cleanup
+
+       appserver(await(detox.cleanup()))

--- a/detox_bridge/__init__.py
+++ b/detox_bridge/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import os
+from contextlib import contextmanager
 
-from . import js
+from . import js, node
 
 node_global = js.Identifier("global")
 detox = node_global.detox
@@ -8,5 +10,22 @@ device = node_global.device
 by = node_global.by
 element = node_global.element
 expect = node_global.expect
-wait_for = node_global.waitFor
+waitFor = node_global.waitFor
 await = js.GlobalAwait
+
+
+@contextmanager
+def node_with_detox(*, app_path, default_timeout):
+    old_cwd = os.getcwd()
+    os.chdir(app_path)
+    app_path = os.getcwd()  # Absolute path
+
+    try:
+        with node.start(default_timeout=default_timeout) as connection:
+            connection("require('{}');".format(
+                os.path.join(app_path, 'node_modules', 'babel-polyfill')))
+            connection("detox = require('{}');".format(
+                os.path.join(app_path, 'node_modules', 'detox')))
+            yield connection
+    finally:
+        os.chdir(old_cwd)

--- a/detox_bridge/bridge.js
+++ b/detox_bridge/bridge.js
@@ -25,20 +25,18 @@ rl.on('line', function(line){
       resolve()
     };
     sandbox.sendResult = (r) => {
-      console.error("Result: "+r);
       sandbox.sendResponse({result: r});
     };
     sandbox.sendError = (e) => {
-      console.error("Send Error: "+e);
       error = {};
       Object.getOwnPropertyNames(e).forEach(function (key) {
           error[key] = e[key];
       });
-      console.error("Error: ");
       sandbox.sendResponse({error:error});
     };
     vm.runInThisContext(`
       try {
+        error = undefined;
         result = (() => { ${command.eval} })();
       }
       catch(e) {
@@ -53,8 +51,6 @@ rl.on('line', function(line){
         Promise.resolve(sandbox.result).then(sandbox.sendResult).catch(sandbox.sendError);
     }
   });
-  return promise.then(()=>{
-    console.error(`Sandbox Globals: ${Object.getOwnPropertyNames(sandbox.global)}`);
-  });
+  return promise;
 });
   

--- a/detox_bridge/node.py
+++ b/detox_bridge/node.py
@@ -15,7 +15,23 @@ class TimeoutError(RuntimeError):
 
 class NodeError(RuntimeError):
     def __init__(self, error):
-        self.__dict__.update(**error)
+        self._error = error
+
+    @property
+    def message(self):
+        return self._error.get("message")
+
+    @property
+    def stack(self):
+        return self._error.get("stack")
+
+    def __str__(self):
+        lines = []
+        for k, v in self._error.items():
+            lines.append("{}:".format(k))
+            for line in v.splitlines():
+                lines.append("  {}".format(line))
+        return "\n".join(lines)
 
 
 def which():

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,6 +2,40 @@
 Usage
 ========
 
-To use detox_bridge in a project::
+To use detox_bridge in a project
+    
+.. code:: python
 
-    import detox_bridge
+   from detox_bridge import await, by, detox, device, element, expect, node_with_detox
+
+   app_path = "detox/examples/demo-react-native"
+
+   # Start Node server in app_path root folder that contains node_modules
+
+   with node_with_detox(app_path=app_path, default_timeout=10) as appserver:
+
+       # Detox Config (we could also load this from package.json)
+
+       ios_sim_release = {
+           "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/example.app",
+           "type": "ios.simulator",
+           "name": "iPhone 7 Plus"
+       }
+
+       configurations_obj = {"configurations": {"ios.sim.release": ios_sim_release}}
+
+       # Longer timeout since the app may be installed
+
+       appserver(await(detox.init(configurations_obj)), timeout=360)
+
+       # Reload react native
+
+       appserver(await(device.reloadReactNative()))
+
+       # Expectation
+
+       appserver(await(expect(element(by.id('welcome'))).toBeVisible()))
+
+       # Cleanup
+
+       appserver(await(detox.cleanup()))

--- a/setup_gen.py
+++ b/setup_gen.py
@@ -12,7 +12,7 @@ write_setup_py(
     author_email='jan-eric.duden@kpn.com',
     url='ssh://git@github.com:kpn-digital/py-detox-bridge.git',
     install_requires=list_requirements('requirements/requirements-base.txt'),
-    packages=find_packages(exclude=['tests*']),
+    packages=find_packages(exclude=['tests*', 'detox']),
     tests_require=['tox'],
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from detox_bridge import js, node
 from pytest import raises
 
@@ -37,8 +39,19 @@ def test_node_server_executes_uses_str_if_object_is_JSObject(node_server):
     node_server(js.Identifier("global").b, timeout=5)
 
 
-def test_node_server_executes_code_reporting_exceptions(node_server):
+def test_node_server_executes_code_reporting_exceptions_and_then_we_can_execute_another_statement(node_server):
     with raises(node.NodeError) as excinfo:
         node_server("throw new Error('hello')", timeout=5)
     assert excinfo.value.message == "hello"
     assert excinfo.value.stack
+
+    node_server("return 4") == 4
+
+
+def test_node_error_str_prints_multiline_exceptions_nicely():
+    assert str(node.NodeError({
+        "stack": "Line 1\nLine 2",
+    })) == dedent("""\
+    stack:
+      Line 1
+      Line 2""")


### PR DESCRIPTION
FIX issue when error was thrown that bridge didn’t work anymore
OPT remove debug prints.
OPT Add test case for waitFor
CHANGE Rename wait_for to waitFor to be consistent with detox naming convention.